### PR TITLE
Changed the order of gcc-flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAIN = text2048
 all:    $(MAIN)
 
 $(MAIN): $(OBJS) 
-	$(CC) $(LIBS) $(CFLAGS) -o $(MAIN) $(OBJS)
+	$(CC) -o $(MAIN) $(OBJS) $(LIBS) $(CFLAGS)
 
 .c.o:
 	$(CC) $(CFLAGS) -c $<  -o $@


### PR DESCRIPTION
This simple change seems to miraculously solve any 'undefined reference'-related errors with Cygwin, mentioned in issue #1.